### PR TITLE
fix(android ocr): change copy location in `prepare.sh`

### DIFF
--- a/ocr/android/app/cxx/ppocr_demo/prepare.sh
+++ b/ocr/android/app/cxx/ppocr_demo/prepare.sh
@@ -5,13 +5,13 @@ fi
 
 
 # copy model
-cp -r ../../../../assets/models/ ./app/src/main/assets/
+cp ../../../../assets/models/* ./app/src/main/assets/
 echo "copy model successed"
 # copy images
-cp -r ../../../../assets/images/   ./app/src/main/assets/
+cp ../../../../assets/images/*   ./app/src/main/assets/
 echo "copy images successed"
 # copy labels
-cp -r ../../../../assets/labels/ ./app/src/main/assets/
+cp ../../../../assets/labels/* ./app/src/main/assets/
 echo "copy labels successed"
 cp ../../../../assets/config.txt ./app/src/main/assets/
 echo "copy config successed"


### PR DESCRIPTION
Change the location of models and labels, or it won't run.